### PR TITLE
Add DockerHub build-and-push workflow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,52 @@
+name: Build and Push Docker Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAMESPACE: ${{ secrets.DOCKERHUB_USERNAME }}
+  IMAGE_PREFIX: cukiller
+
+jobs:
+  build-and-push:
+    name: Build and push ${{ matrix.name }} image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: bot
+            dockerfile: bot.Dockerfile
+          - name: matchmaking
+            dockerfile: matchmaking.Dockerfile
+          - name: graphgetter
+            dockerfile: graphgetter.Dockerfile
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.name }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_PREFIX }}-${{ matrix.name }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_PREFIX }}-${{ matrix.name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and push Docker images for bot, matchmaking, and graphgetter
- publish images with latest and commit SHA tags to Docker Hub using repository secrets

## Testing
- Not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69388e7c83c8832d9becfbd1ff1c91fb)